### PR TITLE
revert: allow to run golangci-lint with go 1.18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.x <1.18
+          go-version: 1.x
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
This reverts commit 9b3f674c7faddda89020df9f5f74c1b6a532e488.

Needs those issues to be solved:
- [ ] golangci/golangci-lint/issues/2649

