### PR TITLE
chore(deps): pin opc-plc docker image to patch version

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
 
   opcua-server-first:
-    image: mcr.microsoft.com/iotedge/opc-plc:2.9
+    image: mcr.microsoft.com/iotedge/opc-plc:2.9.15
     command:
       - --plchostname=opcua-server-first
       - --unsecuretransport
@@ -12,7 +12,7 @@ services:
       - ./pki-server:/app/pki
 
   opcua-server-second:
-    image: mcr.microsoft.com/iotedge/opc-plc:2.9
+    image: mcr.microsoft.com/iotedge/opc-plc:2.9.15
     command:
       - --plchostname=opcua-server-second
       - --disableanonymousauth


### PR DESCRIPTION
Minor version tags are not released, blocking automatic updates.